### PR TITLE
Infrastructure/isolated environment networks

### DIFF
--- a/backend/terraform/chit_chat/chit-chat-def.tpl.json
+++ b/backend/terraform/chit_chat/chit-chat-def.tpl.json
@@ -23,6 +23,10 @@
     ],
     "environment": [
       {
+        "Name": "WEAVE_CIDR",
+        "Value": "net:${weave_cidr}"
+      },
+      {
         "Name": "SECRET_KEY_BASE",
         "Value": "${secret_key_base}"
       },

--- a/backend/terraform/chit_chat/main.tf
+++ b/backend/terraform/chit_chat/main.tf
@@ -37,13 +37,14 @@ data "template_file" "ecs_chit-chat_def" {
     database_password  = "${var.database_password}"
     database_name      = "chit-chat_${var.environment}"
 
-    /*ecs_postgres_name  = "postgres_${var.environment}.servicediscovery.internal"*/
     domain = "${var.domain}"
 
     backend_version = "${var.container_version}"
 
     cloudwatch_log_group = "${aws_cloudwatch_log_group.chit_chat.arn}"
     cloudwatch_region    = "${var.aws_region}"
+
+    weave_cidr = "${var.weave_cidr}"
   }
 }
 
@@ -97,6 +98,7 @@ data "template_file" "ecs_postgres_def" {
     db_password = "${var.database_password}"
     db_name     = "chit-chat_${var.environment}"
     environment = "${var.environment}"
+    weave_cidr = "${var.weave_cidr}"
   }
 }
 

--- a/backend/terraform/chit_chat/main.tf
+++ b/backend/terraform/chit_chat/main.tf
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "chat_chat" {
   name            = "chit-chat_${var.environment}"
   cluster         = "${var.cluster_name}"
   task_definition = "${aws_ecs_task_definition.chit_chat.arn}"
-  desired_count   = 3
+  desired_count   = "${var.num_of_containers}"
   iam_role        = "${aws_iam_role.ecs_service.arn}"
 
   placement_strategy {

--- a/backend/terraform/chit_chat/postgres-def.tpl.json
+++ b/backend/terraform/chit_chat/postgres-def.tpl.json
@@ -12,6 +12,10 @@
     ],
     "environment": [
       {
+        "Name": "WEAVE_CIDR",
+        "Value": "net:${weave_cidr}"
+      },
+      {
         "Name" : "POSTGRES_USER",
         "Value": "${db_username}"
       },

--- a/backend/terraform/chit_chat/variables.tf
+++ b/backend/terraform/chit_chat/variables.tf
@@ -38,6 +38,11 @@ variable "container_version" {
   description = "The version of the container to deploy"
 }
 
+variable "weave_cidr" {
+  type = "string"
+  description = "The Weave subnet to join. This should be unique across applications/environments"
+}
+
 variable "aws_availability_zones" {
   default = "list"
 }

--- a/backend/terraform/chit_chat/variables.tf
+++ b/backend/terraform/chit_chat/variables.tf
@@ -43,6 +43,11 @@ variable "weave_cidr" {
   description = "The Weave subnet to join. This should be unique across applications/environments"
 }
 
+variable "num_of_containers" {
+  type = "string"
+  description = "The number of containers to launch for the service"
+}
+
 variable "aws_availability_zones" {
   default = "list"
 }

--- a/backend/terraform/environments/alpha/main.tf
+++ b/backend/terraform/environments/alpha/main.tf
@@ -10,6 +10,7 @@ module "main" {
 
   container_version = "${var.container_version}"
   weave_cidr = "10.32.100.0/24"
+  num_of_containers = 2
 
   secret_key_base     = "${var.secret_key_base}"
   database_password   = "${var.database_password}"

--- a/backend/terraform/environments/alpha/main.tf
+++ b/backend/terraform/environments/alpha/main.tf
@@ -9,6 +9,7 @@ module "main" {
   domain      = "alpha.chitchat.monarchsofcoding.com"
 
   container_version = "${var.container_version}"
+  weave_cidr = "10.32.100.0/24"
 
   secret_key_base     = "${var.secret_key_base}"
   database_password   = "${var.database_password}"

--- a/backend/terraform/environments/beta/main.tf
+++ b/backend/terraform/environments/beta/main.tf
@@ -10,6 +10,7 @@ module "main" {
 
   container_version = "${var.container_version}"
   weave_cidr = "10.32.101.0/24"
+  num_of_containers = 2
 
   secret_key_base     = "${var.secret_key_base}"
   database_password   = "${var.database_password}"

--- a/backend/terraform/environments/beta/main.tf
+++ b/backend/terraform/environments/beta/main.tf
@@ -9,6 +9,7 @@ module "main" {
   domain      = "beta.chitchat.monarchsofcoding.com"
 
   container_version = "${var.container_version}"
+  weave_cidr = "10.32.101.0/24"
 
   secret_key_base     = "${var.secret_key_base}"
   database_password   = "${var.database_password}"

--- a/backend/terraform/environments/production/main.tf
+++ b/backend/terraform/environments/production/main.tf
@@ -9,6 +9,7 @@ module "main" {
   domain      = "chitchat.monarchsofcoding.com"
 
   container_version = "${var.container_version}"
+  weave_cidr = "10.32.102.0/24"
 
   secret_key_base     = "${var.secret_key_base}"
   database_password   = "${var.database_password}"

--- a/backend/terraform/environments/production/main.tf
+++ b/backend/terraform/environments/production/main.tf
@@ -10,6 +10,7 @@ module "main" {
 
   container_version = "${var.container_version}"
   weave_cidr = "10.32.102.0/24"
+  num_of_containers = 4
 
   secret_key_base     = "${var.secret_key_base}"
   database_password   = "${var.database_password}"

--- a/backend/terraform/weave_cluster/main.tf
+++ b/backend/terraform/weave_cluster/main.tf
@@ -79,8 +79,8 @@ resource "aws_autoscaling_group" "app_cluster" {
   name                 = "${var.cluster_name}.asg"
   vpc_zone_identifier  = ["${aws_subnet.app.*.id}"]
   min_size             = "1"
-  max_size             = "4"
-  desired_capacity     = "2"
+  desired_capacity     = "3"
+  max_size             = "5"
   launch_configuration = "${aws_launch_configuration.app.name}"
 
   tag {


### PR DESCRIPTION
By default, weave net puts all containers on the same network. So, the alpha and beta (and production when it gets deployed) backends were in the same network. The environments tried to communicate with each other, but they couldn't as they had different keys (We have separate keys for each environment), so we would have been fine but it's wasn't ideal. . 

I'm now making use of the `WEAVE_NET` environment variable as documented here: https://www.weave.works/docs/net/latest/ipam/allocation-multi-ipam/ to isolate the environments to be:

- Alpha: `10.32.100.0/24`
- Beta: `10.32.101.0/24`
- Production: `10.32.102.0/24`

The default subnet CIDR in our case is: `10.32.0.0/12`.

I've also allowed us to define how many containers run in each environment, so we can have 2 in alpha, 2 in beta and 4 in production. I might be able to figure out autoscaling (https://www.terraform.io/docs/providers/aws/r/appautoscaling_target.html) if I get the time but for now this will do :champagne: 