### PR TITLE
Infra/update invoke

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - python3-pip
 before_install:
 - sudo pip3 install --upgrade pip
-- sudo pip3 install --upgrade 'invoke-tools>=0.1.9'
+- sudo pip3 install --upgrade 'invoke-tools==0.2.0'
 env:
   global:
     # AWS_ACCESS_KEY_ID

--- a/android_client/e2e/tasks.py
+++ b/android_client/e2e/tasks.py
@@ -1,10 +1,10 @@
 from invoke import task
-from docker import Client
+from docker import APIClient
 import os
 from invoke_tools import lxc, system, vcs
 
 
-cli = Client(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
 
 @task
 def build(ctx):

--- a/android_client/e2e/tasks.py
+++ b/android_client/e2e/tasks.py
@@ -4,7 +4,7 @@ import os
 from invoke_tools import lxc, system, vcs
 
 
-cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600, version="auto")
 
 @task
 def build(ctx):

--- a/android_client/tasks.py
+++ b/android_client/tasks.py
@@ -1,10 +1,10 @@
 from invoke import task
-from docker import Client
+from docker import APIClient
 import os
 from invoke_tools import lxc, system, vcs
 
 
-cli = Client(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
 
 def __check_branch():
   if os.getenv("TRAVIS_PULL_REQUEST") != "false":

--- a/android_client/tasks.py
+++ b/android_client/tasks.py
@@ -4,7 +4,7 @@ import os
 from invoke_tools import lxc, system, vcs
 
 
-cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600, version="auto")
 
 def __check_branch():
   if os.getenv("TRAVIS_PULL_REQUEST") != "false":

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -5,7 +5,7 @@ import shutil
 from invoke_tools import lxc, system, vcs
 
 
-cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600, version="auto")
 
 def __check_branch():
   if os.getenv("TRAVIS_PULL_REQUEST") != "false":

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,11 +1,11 @@
 from invoke import task
-from docker import Client
+from docker import APIClient
 import os
 import shutil
 from invoke_tools import lxc, system, vcs
 
 
-cli = Client(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
 
 def __check_branch():
   if os.getenv("TRAVIS_PULL_REQUEST") != "false":

--- a/java_client/e2e/tasks.py
+++ b/java_client/e2e/tasks.py
@@ -1,9 +1,9 @@
 from invoke import task
-from docker import Client
+from docker import APIClient
 import os
 from invoke_tools import lxc, system, vcs
 
-cli = Client(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
 
 def find_image(repository, tag):
   print("# Looking for {0}:{1}...".format(repository, tag))

--- a/java_client/e2e/tasks.py
+++ b/java_client/e2e/tasks.py
@@ -3,7 +3,7 @@ from docker import APIClient
 import os
 from invoke_tools import lxc, system, vcs
 
-cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600, version="auto")
 
 def find_image(repository, tag):
   print("# Looking for {0}:{1}...".format(repository, tag))

--- a/java_client/tasks.py
+++ b/java_client/tasks.py
@@ -1,10 +1,10 @@
 from invoke import task
-from docker import Client
+from docker import APIClient
 import os
 from invoke_tools import lxc, system, vcs
 
 
-cli = Client(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
 
 def __check_branch():
   if os.getenv("TRAVIS_PULL_REQUEST") != "false":

--- a/java_client/tasks.py
+++ b/java_client/tasks.py
@@ -4,7 +4,7 @@ import os
 from invoke_tools import lxc, system, vcs
 
 
-cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600)
+cli = APIClient(base_url='unix://var/run/docker.sock', timeout=600, version="auto")
 
 def __check_branch():
   if os.getenv("TRAVIS_PULL_REQUEST") != "false":


### PR DESCRIPTION
I've upgraded my `invoke-tools` package to make use of the new Docker engine API so we can use the `invoke` task runner along with `docker-compose`. Previously if we had `invoke-tools` installed, `docker-compose` would give an error saying that `docker-py` was polluting the namespace and couldn't work. This was because docker-compose depended on this newer Docker engine API.

I should have done this at the start of the project, but I thought that there was no backwards compatibility in the new API so I left it. Turns out the old client has just been renamed from `Client` to `APIClient`.

TL;DR. running `invoke` things will work now even if you have `docker-compose` installed.

---

## To review this

### Install invoke-tools on OSX

1. Install python3 using homebrew
```
brew install python3
```
2. Upgrade pip
```
sudo pip3 install --upgrade pip
```
3. Install `invoke-tools`
```
sudo pip3 install --upgrade invoke-tools
```

### Install invoke-tools on linux
1. Install python3 (ubuntu)
```
sudo apt-get install python3 python3-pip
```
2. Install invoke-tools
```
sudo pip3 install --upgrade invoke-tools
```

## Do this after installing
4. Navigate to the project root and do 
```
cd backend
invoke test
```
The tests for the backend should build and run (like they do on Travis).
5. Check if `docker-compose` still works.
```
sudo docker-compose up
```

**ONLY** approve if this all works.
Comment on the PR if you have any trouble and we'll try to resolve it.